### PR TITLE
Turn off lights when starting a game

### DIFF
--- a/Plushie_Module/main.py
+++ b/Plushie_Module/main.py
@@ -82,6 +82,7 @@ class Tool:
             self.topic = '/notify'
             return
         self.log_message('starting game ', number)
+        self.lights.all_off()
         self.running = True
         self.game = number
         


### PR DESCRIPTION
Call self.lights.all_off() when a game is started to check any prior light states are cleared before setting the running flag and game number.

Proposed fix for issue #51  --- Please test before merging @milandahal213 