### PR TITLE
with Splat support on wand

### DIFF
--- a/Bag2/Code/Splat Companion/ble_splat.py
+++ b/Bag2/Code/Splat Companion/ble_splat.py
@@ -1,442 +1,444 @@
 """
-ble_splat.py — BLE driver for Open Splat devices
-==================================================
-Fixed: button debouncing, false trigger prevention,
-removed auto-playSound on button press.
+ble_splat_ctrl.py — Direct Splat BLE Controller for Wand
+==========================================================
+Manages BLE connections from the wand directly to Splat devices,
+bypassing the Splat Companion. Handles connection lifecycle,
+action execution, radio management (ESP-NOW/BLE coexistence),
+and idle signaling.
+
+Requires ble_splat.py in root or /lib/.
+
+Usage:
+    from ble_splat_ctrl import (
+        sp_connect, sp_disconnect_all, sp_keepalive_all,
+        sp_poll_switches_all, sp_process_pending_all,
+        sp_reconnect_lost, sp_has_connections, sp_signal_idle,
+        espnow_pause, espnow_resume, espnow_quick_check,
+        is_sp_trigger, parse_sp_mac,
+    )
 """
 
-import ubluetooth
 import time
-import struct
-import binascii
-import micropython
+import network
 
 
-UUID_SERVICE = ubluetooth.UUID(0xfff0)
-UUID_CHARACTERISTIC_RECV = ubluetooth.UUID(0xfff4)
-UUID_CHARACTERISTIC_WRITE = ubluetooth.UUID(0xfff3)
+# ─────────────────────────────────────────────
+# SP TAG HELPERS
+# ─────────────────────────────────────────────
+def is_sp_trigger(name):
+    return name is not None and name.startswith("SP:")
+
+def parse_sp_mac(name):
+    if not is_sp_trigger(name):
+        return None
+    return name[3:]
 
 
-# Command constants
-KEEP_ALIVE = 0x01, 0x00
-SOUND_OFF = 0x02, 0x00
-ALL_LEDS_OFF = 0x03, 0x00
-ALL_TASKS_OFF = 0x04, 0x00
-READ_SWITCHES = 0x05, 0x00
-READ_BATTERY = 0x06, 0x00
-IDENTIFY_SPLAT = 0x00, 0x10
-SET_VOLUME = 0x01, 0x10
-PLAY_SOUND = 0x00, 0x20
-PLAY_RECORDED_SOUND = 0x01, 0x20
-LEDS_OFF = 0x04, 0x20
-SET_LEDS = 0x01, 0x50
-PLAY_LED_SEQUENCE = 0x01, 0x60
-FLASH_LEDS = 0x01, 0x70
-NOTE_ON = 0x00, 0x40
-NOTE_OFF = 0x01, 0x40
+# ─────────────────────────────────────────────
+# ESP-NOW / BLE RADIO MANAGEMENT
+# ─────────────────────────────────────────────
+# The ESP32-C6 shares a single 2.4GHz antenna between
+# WiFi (ESP-NOW) and BLE. Time-slicing causes unreliable
+# BLE writes when ESP-NOW is active. We pause ESP-NOW
+# during BLE-heavy operations.
 
-# Button debounce
-_DEBOUNCE_MS = 80
+def espnow_pause(mgr):
+    """Pause ESP-NOW to free the radio for BLE."""
+    if mgr and mgr.is_active:
+        try:
+            mgr.enow.active(False)
+        except Exception:
+            pass
+        print("  Radio: ESP-NOW paused for BLE")
 
+def espnow_resume(mgr):
+    """Resume ESP-NOW after BLE operations."""
+    if mgr and mgr.enow is not None:
+        try:
+            mgr.enow.active(True)
+        except Exception:
+            pass
+        print("  Radio: ESP-NOW resumed")
 
-class OpenSplat():
-    def __init__(self, mac_address=None, verbose=False):
-        self._ble = ubluetooth.BLE()
-        self._ble.active(True)
-
-        self.mac_address = mac_address
-
-        self._connection = None
-        self._conn_handle = None
-        self._tx_char_handle = None
-        self._rx_char_handle = None
-
-        self._device_info = {}
-        self._date_time = None
-        self._time_schedule = []
-
-        self.on_splat_pressed = None
-        self.on_splat_released = None
-
-        self.sound = 1
-        self.volume = 255
-
-        # Set up IRQ handler
-        self._ble.irq(self._irq_handler)
-
-        # Connection state
-        self.connected = False
-        self._addr_type = None
-        self.addr = None
-        self.target_addr = None
-        self.device_name = None
-        self._value_handle = None
-        self._start_handle = None
-        self._end_handle = None
-        self._verbose = verbose
-        self._connecting = None
-        self._scanning = False
-
-        # Button state with debounce
-        self.splat_pressed = False
-        self._last_button_change_ms = 0
-        self._last_raw_state = False
-
-    def _irq_handler(self, event, data):
-        """Handle BLE IRQ events"""
-        if event == 1:  # _IRQ_CENTRAL_CONNECT
-            conn_handle, addr_type, addr = data
-            self._conn_handle = conn_handle
-            self.connected = True
-            if self._verbose:
-                print("Connected as central")
-
-        elif event == 2:  # _IRQ_CENTRAL_DISCONNECT
-            self._reset_connection_state()
-            if self._verbose:
-                print("Disconnected")
-
-        elif event == 5:  # _IRQ_SCAN_RESULT
-            self._addr_type, self.addr, adv_type, rssi, adv_data = data
-            self.device_name = self._parse_adv_name(adv_data)
-            self.target_addr = ':'.join(['%02X' % i for i in self.addr])
-
-            if self.target_addr == self.mac_address and not self._connecting:
-                self._ble.gap_scan(None)
-                self._scanning = False
-                self._connecting = True
-                try:
-                    self._ble.gap_connect(self._addr_type, self.addr)
-                    if self._verbose:
-                        print("Connecting...")
-                except Exception as e:
-                    print("Connection failed: %s" % str(e))
-                    self._connecting = False
-
-            elif self.device_name == 'Splat' and not self._connecting:
-                self.mac_address = self.target_addr
-                self._ble.gap_scan(None)
-                self._scanning = False
-
-        elif event == 6:  # _IRQ_SCAN_DONE
-            self._scanning = False
-            if self._verbose:
-                print("Scan complete")
-
-        elif event == 7:  # _IRQ_PERIPHERAL_CONNECT
-            conn_handle, addr_type, addr = data
-            addr_str = ':'.join(['%02X' % i for i in addr])
-
-            if addr_str == self.mac_address:
-                self._conn_handle = conn_handle
-                self.connected = True
-                self._connecting = False
-                if self._verbose:
-                    print("Connected! Discovering services...")
-                self._ble.gattc_discover_services(self._conn_handle)
-
-        elif event == 8:  # _IRQ_PERIPHERAL_DISCONNECT
-            self._reset_connection_state()
-            if self._verbose:
-                print("Peripheral disconnected")
-
-        elif event == 9:  # _IRQ_GATTC_SERVICE_RESULT
-            conn_handle, start_handle, end_handle, uuid = data
-            if uuid == UUID_SERVICE:
-                self._start_handle = start_handle
-                self._end_handle = end_handle
-                if self._verbose:
-                    print("Service found: %d-%d" % (start_handle, end_handle))
-
-        elif event == 10:  # _IRQ_GATTC_SERVICE_DONE
-            if self._start_handle and self._end_handle:
-                self._ble.gattc_discover_characteristics(
-                    self._conn_handle, self._start_handle, self._end_handle
-                )
-            else:
-                print("Required service not found")
-
-        elif event == 11:  # _IRQ_GATTC_CHARACTERISTIC_RESULT
-            conn_handle, def_handle, value_handle, properties, uuid = data
-            if uuid == UUID_CHARACTERISTIC_WRITE:
-                self._tx_char_handle = value_handle
-            elif uuid == UUID_CHARACTERISTIC_RECV:
-                self._rx_char_handle = value_handle
-
-        elif event == 12:  # _IRQ_GATTC_CHARACTERISTIC_DONE
-            if self._rx_char_handle:
-                self._subscribe_to_notifications()
-            if self._verbose:
-                print("Setup complete!")
-
-        elif event == 17:  # _IRQ_GATTC_WRITE_DONE
-            conn_handle, value_handle, status = data
-            if self._verbose and status != 0:
-                print("Write error: %d" % status)
-
-        elif event == 18:  # _IRQ_GATTC_NOTIFY
-            conn_handle, value_handle, notify_data = data
-            if value_handle == self._rx_char_handle:
-                self._process_notification(notify_data)
-
-    def _parse_adv_name(self, adv_data):
-        """Parse device name from advertising data"""
-        i = 0
-        while i < len(adv_data):
-            length = adv_data[i]
-            if length == 0:
-                break
-            ad_type = adv_data[i + 1]
-            if ad_type == 0x09 or ad_type == 0x08:
-                name_bytes = adv_data[i + 2:i + 1 + length]
-                try:
-                    return bytes(name_bytes).decode('utf-8')
-                except:
-                    return None
-            i += 1 + length
+def espnow_quick_check(mgr, check_broadcast_fn, batt_ref, leds_ref, buz_ref):
+    """
+    Briefly enable ESP-NOW, poll for stop/battery, then disable.
+    check_broadcast_fn: the check_broadcast function from main.
+    Returns "stop", "battery", or None.
+    """
+    if mgr is None or mgr.enow is None:
+        return None
+    try:
+        mgr.enow.active(True)
+        time.sleep_ms(5)
+        result = check_broadcast_fn(mgr, batt_ref, leds_ref, buz_ref)
+        mgr.enow.active(False)
+        return result
+    except Exception:
         return None
 
-    def _reset_connection_state(self):
-        """Reset all connection-related state"""
-        self.connected = False
-        self._conn_handle = None
-        self._connecting = False
-        self._tx_char_handle = None
-        self._rx_char_handle = None
-        self._start_handle = None
-        self._end_handle = None
 
-    def _process_notification(self, buffer):
-        """Process notifications from the Splat device"""
-        if len(buffer) >= 11 and buffer[0] == 0x66 and buffer[11] == 0x99:
-            # Device info packet
-            if self._verbose:
-                value = ':'.join(['%02X' % i for i in buffer])
-                print("Device info: %s" % value)
+# ─────────────────────────────────────────────
+# ACTION MAPS (Splat command parameters)
+# ─────────────────────────────────────────────
+SP_COLOR_RGB = {
+    "turnred": (255, 0, 0), "turngreen": (0, 255, 0),
+    "turnblue": (0, 0, 255), "turnpurple": (160, 0, 200),
+    "turnyellow": (255, 180, 0), "turnwhite": (200, 200, 200),
+    "turnoff": (0, 0, 0),
+}
 
-        elif len(buffer) >= 10 and buffer[0] == 0x13 and buffer[10] == 0x31:
-            # Date/time packet
-            if self._verbose:
-                print("Received date/time")
+SP_NOTE_MAP = {
+    "notec": 1, "noted": 3, "notee": 6, "notef": 7,
+    "noteg": 10, "notea": 13, "noteb": 15, "playnote": 1,
+}
 
+SP_ANIMAL_SOUNDS = {
+    "cat": 19, "chicken": 20, "cow": 21, "dog": 22,
+    "pig": 23, "duck": 24, "elephant": 25, "horse": 26, "goat": 28,
+}
+
+SP_DEFAULT_OCTAVE = 4
+SP_DEFAULT_VELOCITY = 255
+SP_DEFAULT_INSTRUMENT = 16
+SP_DEFAULT_SOUND_VOL = 255
+
+
+# ─────────────────────────────────────────────
+# ACTION PARSER
+# ─────────────────────────────────────────────
+def _parse_sp_actions(chain):
+    """Parse action chain into color/note/sound lists for Splat."""
+    colors, notes, sounds = [], [], []
+    for group in chain:
+        gc, gn, gs = None, None, None
+        for a in group:
+            if a in SP_COLOR_RGB:
+                gc = a
+            elif a in SP_NOTE_MAP:
+                gn = a
+            elif a in SP_ANIMAL_SOUNDS:
+                gs = a
+        colors.append(gc)
+        notes.append(gn)
+        sounds.append(gs)
+    return colors, notes, sounds
+
+
+# ─────────────────────────────────────────────
+# DIRECT SPLAT CONTROLLER
+# ─────────────────────────────────────────────
+class DirectSplatController:
+    """
+    Manages a direct BLE connection from the wand to a Splat.
+
+    IMPORTANT: on_press/on_release are called from the BLE IRQ
+    context (notification handler). You CANNOT do gattc_write from
+    inside an IRQ — it silently fails. Instead we set a pending
+    flag and the main loop calls process_pending() to execute
+    the actual BLE commands.
+    """
+    def __init__(self, splat):
+        self.splat = splat
+        self.colors = []
+        self.notes = []
+        self.sounds = []
+        self.configured = False
+        self.active_notes = []
+        self._pending_press = False
+        self._pending_release = False
+        self._has_notes = False
+        self._was_pressed = False
+
+    def set_config(self, chain):
+        self.colors, self.notes, self.sounds = _parse_sp_actions(chain)
+        self.configured = True
+        self.active_notes = []
+        self._pending_press = False
+        self._pending_release = False
+        self._has_notes = any(n is not None for n in self.notes)
+        if self._has_notes:
+            # Splat button notifications corrupt the note engine.
+            # Disable callbacks — wand button will be used instead.
+            print("  SP: Notes detected — use wand button to trigger")
+            self.splat.on_splat_pressed = None
+            self.splat.on_splat_released = None
         else:
-            data = [d for d in buffer]
-            # Button state notification: [3, X, button_byte]
-            if data[0] == 3 and len(data) == 3:
-                self._handle_button(data[2])
-            elif self._verbose:
-                print("Unknown notification: %s" % str(data))
+            self.splat.on_splat_pressed = self.on_press
+            self.splat.on_splat_released = self.on_release
+        print("  SP Config: %d groups (has_notes=%s)" % (len(chain), self._has_notes))
 
-    def _handle_button(self, value):
-        """
-        Process button state with debouncing.
-        Prevents false triggers from noisy BLE notifications.
-
-        value: bitmask of pressed buttons (any bit set = pressed)
-        """
-        now = time.ticks_ms()
-
-        # Determine current raw state
-        raw_pressed = bool(value & 0x0F)  # any of the 4 button bits
-
-        # Ignore if same as last raw state (no change)
-        if raw_pressed == self._last_raw_state:
-            return
-        self._last_raw_state = raw_pressed
-
-        # Debounce: ignore if too soon after last change
-        if time.ticks_diff(now, self._last_button_change_ms) < _DEBOUNCE_MS:
-            return
-        self._last_button_change_ms = now
-
-        was_pressed = self.splat_pressed
-
-        if raw_pressed and not was_pressed:
-            # Button just pressed
-            self.splat_pressed = True
-            if self.on_splat_pressed:
+    def clear_config(self):
+        self.colors = []; self.notes = []; self.sounds = []
+        self.configured = False
+        self._pending_press = False
+        self._pending_release = False
+        if self.splat.connected:
+            for mn in self.active_notes:
                 try:
-                    self.on_splat_pressed()
-                except Exception as e:
-                    print("  Press callback error: %s" % str(e))
-
-        elif not raw_pressed and was_pressed:
-            # Button just released
-            self.splat_pressed = False
-            if self.on_splat_released:
-                try:
-                    self.on_splat_released()
-                except Exception as e:
-                    print("  Release callback error: %s" % str(e))
-
-    def _subscribe_to_notifications(self):
-        """Subscribe to device notifications"""
-        if self._rx_char_handle:
+                    self.splat.noteOff(mn, SP_DEFAULT_VELOCITY, SP_DEFAULT_OCTAVE, SP_DEFAULT_INSTRUMENT)
+                except Exception:
+                    pass
             try:
-                self._ble.gattc_write(
-                    self._conn_handle, self._rx_char_handle + 1, b'\x01\x00'
-                )
-                if self._verbose:
-                    print("Subscribed to notifications")
-            except Exception as e:
-                print("Subscription failed: %s" % str(e))
+                self.splat.allLEDsOff()
+            except Exception:
+                pass
+        self.active_notes = []
 
-    def _write_command(self, data):
-        """Write command to Splat device"""
-        if not self.connected or self._tx_char_handle is None:
-            if self._verbose:
-                print("Not connected or TX characteristic not found")
+    def on_press(self):
+        """Called from BLE IRQ — just set flag, don't do BLE writes."""
+        if not self.configured:
+            return
+        self._pending_press = True
+        self._pending_release = False
+
+    def on_release(self):
+        """Called from BLE IRQ — just set flag, don't do BLE writes."""
+        if not self.configured:
+            return
+        self._pending_release = True
+
+    def process_pending(self):
+        """
+        Called from main loop. Processes pending press/release from callbacks.
+        For note configs, use wand_button_event() instead.
+        """
+        if self._has_notes:
+            # Handled by wand_button_event() from sp_loop
             return False
+        if self._pending_press:
+            self._pending_press = False
+            self._do_press()
+            return True
+        if self._pending_release:
+            self._pending_release = False
+            self._do_release()
+            return True
+        return False
 
+    def wand_button_event(self, pressed):
+        """
+        Called from sp_loop when wand physical button changes state.
+        Used when notes are in the config since Splat button notifications
+        corrupt the note engine.
+        """
+        if not self.configured or not self.splat.connected:
+            return
+        if pressed:
+            self._do_press()
+        else:
+            self._do_release()
+
+    def _do_press(self):
+        if not self.splat.connected:
+            return
+        print("  SP PRESSED")
+        self.active_notes = []
+        for i in range(len(self.colors)):
+            c, n, s = self.colors[i], self.notes[i], self.sounds[i]
+            # LED first — most visible, least likely to block
+            if c and c in SP_COLOR_RGB:
+                try:
+                    self.splat.setLEDsON(SP_COLOR_RGB[c])
+                except Exception as e:
+                    print("    SP LED err: %s" % str(e))
+                time.sleep_ms(30)
+            # Sound second — fire-and-forget
+            if s and s in SP_ANIMAL_SOUNDS:
+                try:
+                    self.splat.playSound(SP_ANIMAL_SOUNDS[s], SP_DEFAULT_SOUND_VOL)
+                except Exception as e:
+                    print("    SP Sound err: %s" % str(e))
+                time.sleep_ms(30)
+            # Note last — can put Splat in sustained state
+            if n and n in SP_NOTE_MAP:
+                mn = SP_NOTE_MAP[n]
+                print("    SP Note: %s -> val=%d, oct=%d, vel=%d, inst=%d" % (n, mn, SP_DEFAULT_OCTAVE, SP_DEFAULT_VELOCITY, SP_DEFAULT_INSTRUMENT))
+                try:
+                    self.splat.noteOn(mn, SP_DEFAULT_VELOCITY, SP_DEFAULT_OCTAVE, SP_DEFAULT_INSTRUMENT)
+                    self.active_notes.append(mn)
+                except Exception as e:
+                    print("    SP Note err: %s" % str(e))
+                time.sleep_ms(30)
+            if i < len(self.colors) - 1:
+                time.sleep_ms(400)
+
+    def _do_release(self):
+        if not self.splat.connected:
+            return
+        print("  SP RELEASED")
+        self._stop_all()
+
+    def _stop_all(self):
+        if not self.splat.connected:
+            return
+        # allTasksOff is a nuclear reset — stops notes, sounds,
+        # LED sequences, everything in one command. Much more
+        # reliable than 3 separate writes that can collide.
         try:
-            self._ble.gattc_write(self._conn_handle, self._tx_char_handle, data)
-            if self._verbose:
-                print("Sent: %s" % str([hex(b) for b in data]))
+            self.splat.allTasksOff()
+        except Exception:
+            pass
+        self.active_notes = []
+
+
+# ─────────────────────────────────────────────
+# CONNECTION MANAGER
+# ─────────────────────────────────────────────
+_sp_connections = {}   # { "SP:<MAC>": { "splat": OpenSplat, "ctrl": DirectSplatController } }
+
+
+def sp_connect(sp_mac, leds, mgr=None):
+    """
+    Connect to a Splat device via BLE.
+    sp_mac: BLE MAC string like "AB:42:00:00:7E:B6"
+    leds: Leds instance for status feedback.
+    mgr: ESPNowManager — will be paused during BLE connect.
+    Returns (OpenSplat, DirectSplatController) or (None, None).
+    """
+    from ble_splat import OpenSplat
+
+    key = "SP:" + sp_mac
+    if key in _sp_connections:
+        entry = _sp_connections[key]
+        if entry["splat"].connected:
+            return entry["splat"], entry["ctrl"]
+        else:
+            print("  SP: stale connection for %s, reconnecting..." % sp_mac)
+            try:
+                entry["splat"].disconnect()
+            except Exception:
+                pass
+
+    print("  SP: Connecting to Splat %s via BLE..." % sp_mac)
+    leds.solid(0, 0, 15)
+
+    espnow_pause(mgr)
+
+    splat = OpenSplat(mac_address=sp_mac, verbose=False)
+    ctrl = DirectSplatController(splat)
+    splat.on_splat_pressed = ctrl.on_press
+    splat.on_splat_released = ctrl.on_release
+
+    ok = splat.connect(timeout=15)
+    if not ok:
+        print("  SP: First attempt failed, retrying...")
+        leds.flash(15, 8, 0, times=3, on_ms=80, off_ms=60)
+        ok = splat.connect(timeout=15)
+
+    if not ok:
+        print("  SP: [FAIL] Could not connect to Splat %s" % sp_mac)
+        leds.flash(15, 0, 0, times=5, on_ms=80, off_ms=60)
+        espnow_resume(mgr)
+        return None, None
+
+    print("  SP: BLE connected to %s!" % sp_mac)
+    leds.flash(0, 15, 0, times=3, on_ms=80, off_ms=60)
+
+    # NOTE: Do NOT call identifySplat() here — it starts an LED
+    # sequence on the Splat that blocks subsequent setLEDsON commands.
+
+    _sp_connections[key] = {"splat": splat, "ctrl": ctrl}
+    return splat, ctrl
+
+
+def sp_signal_idle(entry):
+    """Flash an LED pattern on the Splat to indicate idle/disconnected."""
+    splat = entry["splat"]
+    if not splat.connected:
+        return
+    try:
+        splat.soundOff()
+        time.sleep_ms(30)
+        splat.allLEDsOff()
+        time.sleep_ms(50)
+        # Flash orange 3 times
+        for _ in range(3):
+            splat.setLEDsON((255, 80, 0))
+            time.sleep_ms(200)
+            splat.allLEDsOff()
+            time.sleep_ms(150)
+    except Exception as e:
+        print("  SP idle signal err: %s" % str(e))
+
+
+def sp_disconnect_all(mgr=None):
+    """Signal idle on all Splats, then disconnect."""
+    for key in list(_sp_connections.keys()):
+        entry = _sp_connections[key]
+        try:
+            entry["ctrl"].clear_config()
+        except Exception:
+            pass
+        sp_signal_idle(entry)
+        try:
+            entry["splat"].disconnect()
+        except Exception:
+            pass
+        print("  SP: Disconnected %s" % key)
+    _sp_connections.clear()
+    espnow_resume(mgr)
+
+
+def sp_keepalive_all():
+    """Send keepalive to all connected Splats."""
+    for key, entry in _sp_connections.items():
+        if entry["splat"].connected:
+            try:
+                entry["splat"].keepAlive()
+            except Exception:
+                pass
+
+
+def sp_poll_switches_all():
+    """No longer needed — Splat sends button notifications via interrupt.
+    Kept as no-op for compatibility in case sp_loop.py calls it."""
+    pass
+
+
+def sp_process_pending_all():
+    """Process any pending press/release actions from BLE IRQ callbacks."""
+    for key, entry in _sp_connections.items():
+        entry["ctrl"].process_pending()
+
+
+def sp_reconnect_lost(leds, mgr=None):
+    """Check for lost connections and attempt reconnect."""
+    for key in list(_sp_connections.keys()):
+        entry = _sp_connections[key]
+        if not entry["splat"].connected:
+            sp_mac = key[3:]
+            print("  SP: [WARN] BLE lost for %s — reconnecting..." % sp_mac)
+            leds.solid(0, 0, 15)
+            espnow_pause(mgr)
+            ok = entry["splat"].connect(timeout=10)
+            if ok:
+                print("  SP: Reconnected %s!" % sp_mac)
+                leds.flash(0, 15, 0, times=2, on_ms=80, off_ms=60)
+            else:
+                print("  SP: Reconnect failed for %s" % sp_mac)
+
+
+def sp_has_connections():
+    """Check if any SP connections exist."""
+    return len(_sp_connections) > 0
+
+
+def sp_has_notes():
+    """Check if any SP connection has notes configured."""
+    for key, entry in _sp_connections.items():
+        if entry["ctrl"]._has_notes:
             return True
-        except Exception as e:
-            print("Send error: %s" % str(e))
-            return False
+    return False
 
-    def decode_button(self, value):
-        """Legacy method — now handled by _handle_button"""
-        self._handle_button(value)
 
-    def scanSplat(self, timeout=5):
-        """Scan for nearby Splat device"""
-        print("Scanning for Splat...")
-        self._reset_connection_state()
+def sp_wand_button_event(pressed):
+    """Forward wand button event to all SP controllers with notes."""
+    for key, entry in _sp_connections.items():
+        if entry["ctrl"]._has_notes:
+            entry["ctrl"].wand_button_event(pressed)
 
-        self._scanning = True
-        self._ble.gap_scan(0, 1000, 1000)
 
-        start = time.time()
-        while self._scanning and (time.time() - start < timeout):
-            time.sleep(0.1)
-
-        if self._scanning:
-            self._ble.gap_scan(None)
-            self._scanning = False
-
-        return self.mac_address
-
-    def connect(self, timeout=30):
-        """Connect to the Splat device"""
-        self._ble.active(True)
-
-        if self.connected:
-            return True
-
-        self._reset_connection_state()
-
-        self._scanning = True
-        self._ble.gap_scan(0, 30000, 30000)
-
-        start_time = time.time()
-        while not self.connected and (time.time() - start_time < timeout):
-            if not self._scanning and not self._connecting:
-                self._scanning = True
-                self._ble.gap_scan(0, 30000, 30000)
-            print(".", end="")
-            time.sleep(0.5)
-
-        if self._scanning:
-            self._ble.gap_scan(None)
-            self._scanning = False
-
-        if not self.connected:
-            print("\nConnection timeout after %ds" % timeout)
-            return False
-
-        start_time = time.time()
-        while (not self._tx_char_handle or not self._rx_char_handle) and (time.time() - start_time < 10):
-            time.sleep(0.5)
-
-        if not self._tx_char_handle or not self._rx_char_handle:
-            print("\nService setup failed")
-            self.disconnect()
-            return False
-
-        print("\nConnected successfully!")
-        return True
-
-    def disconnect(self):
-        """Disconnect from device"""
-        if self._conn_handle is not None:
-            self._ble.gap_disconnect(self._conn_handle)
-            self._conn_handle = None
-            self.connected = False
-            if self._verbose:
-                print("Disconnected from Splat")
-            self._ble.active(False)
-
-    def is_connected(self):
-        """Check if connected to device"""
-        return self.connected
-
-    # ── Command implementations ──
-
-    def keepAlive(self):
-        return self._write_command(bytearray(KEEP_ALIVE))
-
-    def soundOff(self):
-        return self._write_command(bytearray(SOUND_OFF))
-
-    def allLEDsOff(self):
-        return self._write_command(bytearray(ALL_LEDS_OFF))
-
-    def allTasksOff(self):
-        return self._write_command(bytearray(ALL_TASKS_OFF))
-
-    def readSwitches(self):
-        return self._write_command(bytearray(READ_SWITCHES))
-
-    def readBattery(self):
-        return self._write_command(bytearray(READ_BATTERY))
-
-    def identifySplat(self):
-        return self._write_command(bytearray(IDENTIFY_SPLAT))
-
-    def setVolume(self, vol):
-        return self._write_command(bytearray(SET_VOLUME + (vol,)))
-
-    def playSound(self, soundIndex, vol):
-        return self._write_command(bytearray(PLAY_SOUND + (soundIndex, vol)))
-
-    def playRecordedSound(self, soundIndex, vol):
-        return self._write_command(bytearray(PLAY_RECORDED_SOUND + (soundIndex, vol)))
-
-    def LEDsOff(self, lowByte, highByte):
-        return self._write_command(bytearray(LEDS_OFF + (lowByte, highByte)))
-
-    def setLEDsON(self, color):
-        return self._write_command(bytearray(
-            SET_LEDS + (0xFF, 0x3F, color[0], color[1], color[2])
-        ))
-
-    def setLEDs(self, leds, red, green, blue):
-        value = 0
-        for led in leds:
-            value = value | 1 << led
-        return self._write_command(bytearray(
-            SET_LEDS + (value & 0xFF, value >> 8 & 0xFF, red, green, blue)
-        ))
-
-    def playLEDSequence(self, seqIndex, red, green, blue, duration, loops):
-        return self._write_command(bytearray(
-            PLAY_LED_SEQUENCE + (seqIndex, red, green, blue, duration, loops)
-        ))
-
-    def flashLEDs(self, lowByte, highByte, red, green, blue, duration, flashes):
-        return self._write_command(bytearray(
-            FLASH_LEDS + (lowByte, highByte, red, green, blue, duration, flashes)
-        ))
-
-    def noteOn(self, note, velocity, octave, instrument):
-        return self._write_command(bytearray(
-            NOTE_ON + (note, octave, velocity, instrument)
-        ))
-
-    def noteOff(self, note, velocity, octave, instrument):
-        return self._write_command(bytearray(
-            NOTE_OFF + (note, octave, velocity, instrument)
-        ))
+def sp_get_connections():
+    """Return the connections dict (for cleanup in main)."""
+    return _sp_connections

--- a/Bag2/Code/Wand Module/ble_splat_ctrl.py
+++ b/Bag2/Code/Wand Module/ble_splat_ctrl.py
@@ -1,0 +1,280 @@
+"""
+ble_splat_ctrl.py — Direct Splat BLE Controller for Wand (v4)
+================================================================
+Split from the working unified main.py.
+IMPORTANT: After copying to device, verify version prints on boot.
+"""
+
+_VERSION = "v4"
+
+import time
+import network
+
+
+# ─────────────────────────────────────────────
+# SP TAG HELPERS
+# ─────────────────────────────────────────────
+def is_sp_trigger(name):
+    return name is not None and name.startswith("SP:")
+
+def parse_sp_mac(name):
+    if not is_sp_trigger(name): return None
+    return name[3:]
+
+
+# ─────────────────────────────────────────────
+# ESP-NOW / BLE RADIO MANAGEMENT
+# ─────────────────────────────────────────────
+def espnow_pause(mgr):
+    if mgr and mgr.is_active:
+        try: mgr.enow.active(False)
+        except Exception: pass
+        print("  Radio: ESP-NOW paused for BLE")
+
+def espnow_resume(mgr):
+    if mgr and mgr.enow is not None:
+        try: mgr.enow.active(True)
+        except Exception: pass
+        print("  Radio: ESP-NOW resumed")
+
+def espnow_quick_check(mgr, check_broadcast_fn, batt_ref, leds_ref, buz_ref):
+    if mgr is None or mgr.enow is None: return None
+    try:
+        mgr.enow.active(True)
+        time.sleep_ms(5)
+        result = check_broadcast_fn(mgr, batt_ref, leds_ref, buz_ref)
+        mgr.enow.active(False)
+        return result
+    except Exception: return None
+
+
+# ─────────────────────────────────────────────
+# ACTION MAPS
+# ─────────────────────────────────────────────
+SP_COLOR_RGB = {
+    "turnred": (255, 0, 0), "turngreen": (0, 255, 0),
+    "turnblue": (0, 0, 255), "turnpurple": (160, 0, 200),
+    "turnyellow": (255, 180, 0), "turnwhite": (200, 200, 200),
+    "turnoff": (0, 0, 0),
+}
+
+SP_NOTE_MAP = {
+    "notec": 1, "noted": 3, "notee": 6, "notef": 7,
+    "noteg": 10, "notea": 13, "noteb": 15, "playnote": 1,
+}
+
+SP_ANIMAL_SOUNDS = {
+    "cat": 19, "chicken": 20, "cow": 21, "dog": 22,
+    "pig": 23, "duck": 24, "elephant": 25, "horse": 26, "goat": 28,
+}
+
+SP_DEFAULT_OCTAVE = 4
+SP_DEFAULT_VELOCITY = 255
+SP_DEFAULT_INSTRUMENT = 16
+SP_DEFAULT_SOUND_VOL = 255
+
+
+def _parse_sp_actions(chain):
+    colors, notes, sounds = [], [], []
+    for group in chain:
+        gc, gn, gs = None, None, None
+        for a in group:
+            if a in SP_COLOR_RGB: gc = a
+            elif a in SP_NOTE_MAP: gn = a
+            elif a in SP_ANIMAL_SOUNDS: gs = a
+        colors.append(gc); notes.append(gn); sounds.append(gs)
+    return colors, notes, sounds
+
+
+# ─────────────────────────────────────────────
+# DIRECT SPLAT CONTROLLER
+# ─────────────────────────────────────────────
+class DirectSplatController:
+    def __init__(self, splat):
+        self.splat = splat
+        self.colors = []
+        self.notes = []
+        self.sounds = []
+        self.configured = False
+        self.active_notes = []
+        self._pending_press = False
+        self._pending_release = False
+
+    def set_config(self, chain):
+        self.colors, self.notes, self.sounds = _parse_sp_actions(chain)
+        self.configured = True
+        self.active_notes = []
+        self._pending_press = False
+        self._pending_release = False
+        self.splat.on_splat_pressed = self.on_press
+        self.splat.on_splat_released = self.on_release
+        self.splat.splat_pressed = False
+        self.splat._last_raw_state = False
+        self.splat._last_button_change_ms = 0
+        print("  SP Config: %d groups" % len(chain))
+
+    def clear_config(self):
+        self.colors = []; self.notes = []; self.sounds = []
+        self.configured = False
+        self._pending_press = False
+        self._pending_release = False
+        self.active_notes = []
+        if self.splat.connected:
+            try: self.splat.allLEDsOff()
+            except Exception: pass
+
+    def on_press(self):
+        if not self.configured: return
+        self._pending_press = True
+        self._pending_release = False
+
+    def on_release(self):
+        if not self.configured: return
+        self._pending_release = True
+
+    def process_pending(self):
+        if self._pending_press:
+            self._pending_press = False
+            self._do_press()
+            return True
+        if self._pending_release:
+            self._pending_release = False
+            self._do_release()
+            return True
+        return False
+
+    def _do_press(self):
+        if not self.splat.connected: return
+        print("  SP PRESSED")
+        self.active_notes = []
+        for i in range(len(self.colors)):
+            c, n, s = self.colors[i], self.notes[i], self.sounds[i]
+            if c and c in SP_COLOR_RGB:
+                rgb = SP_COLOR_RGB[c]
+                try:
+                    self.splat._ble.gattc_write(
+                        self.splat._conn_handle, self.splat._tx_char_handle,
+                        bytearray([0x01, 0x50, 0xFF, 0x3F, rgb[0], rgb[1], rgb[2]]))
+                except Exception as e:
+                    print("    LED err: %s" % str(e))
+                time.sleep_ms(30)
+            if s and s in SP_ANIMAL_SOUNDS:
+                try:
+                    self.splat._ble.gattc_write(
+                        self.splat._conn_handle, self.splat._tx_char_handle,
+                        bytearray([0x00, 0x20, SP_ANIMAL_SOUNDS[s], SP_DEFAULT_SOUND_VOL]))
+                except Exception as e:
+                    print("    Sound err: %s" % str(e))
+                time.sleep_ms(30)
+            if n and n in SP_NOTE_MAP:
+                mn = SP_NOTE_MAP[n]
+                try:
+                    self.splat._ble.gattc_write(
+                        self.splat._conn_handle, self.splat._tx_char_handle,
+                        bytearray([0, 64, mn, SP_DEFAULT_OCTAVE, SP_DEFAULT_VELOCITY, SP_DEFAULT_INSTRUMENT]))
+                    self.active_notes.append(mn)
+                except Exception as e:
+                    print("    Note err: %s" % str(e))
+                time.sleep_ms(30)
+            if i < len(self.colors) - 1:
+                time.sleep_ms(400)
+
+    def _do_release(self):
+        if not self.splat.connected: return
+        print("  SP RELEASED")
+        for mn in self.active_notes:
+            try:
+                self.splat._ble.gattc_write(
+                    self.splat._conn_handle, self.splat._tx_char_handle,
+                    bytearray([1, 64, mn, SP_DEFAULT_OCTAVE, SP_DEFAULT_VELOCITY, SP_DEFAULT_INSTRUMENT]))
+            except Exception: pass
+        self.active_notes = []
+        try:
+            self.splat._ble.gattc_write(
+                self.splat._conn_handle, self.splat._tx_char_handle,
+                bytearray([0x03, 0x00]))
+        except Exception: pass
+
+
+# ─────────────────────────────────────────────
+# CONNECTION MANAGER
+# ─────────────────────────────────────────────
+_sp_connections = {}
+
+
+def sp_connect(sp_mac, leds, mgr=None):
+    from ble_splat import OpenSplat
+    key = "SP:" + sp_mac
+    if key in _sp_connections:
+        entry = _sp_connections[key]
+        if entry["splat"].connected:
+            return entry["splat"], entry["ctrl"]
+        try: entry["splat"].disconnect()
+        except Exception: pass
+
+    print("  SP: Connecting to Splat %s via BLE..." % sp_mac)
+    leds.solid(0, 0, 15)
+    espnow_pause(mgr)
+
+    splat = OpenSplat(mac_address=sp_mac, verbose=False)
+    ctrl = DirectSplatController(splat)
+
+    ok = splat.connect(timeout=15)
+    if not ok:
+        leds.flash(15, 8, 0, times=3, on_ms=80, off_ms=60)
+        ok = splat.connect(timeout=15)
+    if not ok:
+        print("  SP: [FAIL] Could not connect to %s" % sp_mac)
+        leds.flash(15, 0, 0, times=5, on_ms=80, off_ms=60)
+        espnow_resume(mgr)
+        return None, None
+
+    print("  SP: BLE connected to %s!" % sp_mac)
+    leds.flash(0, 15, 0, times=3, on_ms=80, off_ms=60)
+    _sp_connections[key] = {"splat": splat, "ctrl": ctrl}
+    return splat, ctrl
+
+
+def sp_signal_idle(entry):
+    splat = entry["splat"]
+    if not splat.connected: return
+    try:
+        splat.allLEDsOff()
+        time.sleep_ms(50)
+        for _ in range(3):
+            splat.setLEDsON((255, 80, 0))
+            time.sleep_ms(200)
+            splat.allLEDsOff()
+            time.sleep_ms(150)
+    except Exception: pass
+
+
+def sp_disconnect_all(leds, mgr=None):
+    for key in list(_sp_connections.keys()):
+        entry = _sp_connections[key]
+        try: entry["ctrl"].clear_config()
+        except Exception: pass
+        sp_signal_idle(entry)
+        try: entry["splat"].disconnect()
+        except Exception: pass
+    _sp_connections.clear()
+    espnow_resume(mgr)
+
+
+def sp_keepalive_all():
+    for key, entry in _sp_connections.items():
+        if entry["splat"].connected:
+            try: entry["splat"].keepAlive()
+            except Exception: pass
+
+
+def sp_process_pending_all():
+    for key, entry in _sp_connections.items():
+        entry["ctrl"].process_pending()
+
+
+def sp_get_connections():
+    return _sp_connections
+
+
+print("[ble_splat_ctrl %s loaded]" % _VERSION)

--- a/Bag2/Code/Wand Module/main.py
+++ b/Bag2/Code/Wand Module/main.py
@@ -1,15 +1,13 @@
 """
-PlaygroundV5 – NFC Multi-Trigger Event Engine + Splat Companion
-================================================================
+PlaygroundV5 – NFC Event Engine + Direct Splat BLE (v4)
+=========================================================
 Board: Seeed XIAO ESP32-C6
 Requires hubtype.txt containing: wand
 
-Triggers: buttondown, buttonup, shake, gesture:<n>, SC:<MAC>
-Actions:  playnote, notea-g, turnred/green/blue/purple/yellow/white/off,
-          cat, chicken, cow, dog, pig, duck, elephant, horse, goat
-Combinators: and, then
-Controls: start, stop, colorquest, freezedance
-Utility: battery
+IMPORTANT: When updating, copy ALL THREE files to the device:
+  main.py, ble_splat_ctrl.py, sp_loop.py
+  Also ble_splat.py and nfc_reader.py (in /lib/)
+  MicroPython caches imports — stale files cause bugs.
 """
 
 import machine
@@ -32,8 +30,15 @@ from espnow_manager import ESPNowManager
 from color_quest import play as play_color_quest
 from freeze_dance import play as play_freeze_dance
 
+from ble_splat_ctrl import (
+    is_sp_trigger, parse_sp_mac,
+    sp_connect, sp_disconnect_all, sp_signal_idle, sp_get_connections,
+    espnow_pause, espnow_resume,
+)
+from sp_loop import run_sp_loop
+
 # ─────────────────────────────────────────────
-# PINS FROM HUBTYPE
+# PINS
 # ─────────────────────────────────────────────
 I2C_SDA      = HUB_CONFIG["i2c_sda"]
 I2C_SCL      = HUB_CONFIG["i2c_scl"]
@@ -63,14 +68,13 @@ int1_pin = machine.Pin(ACCEL_INT1, machine.Pin.IN)
 motor    = machine.Pin(MOTOR_PIN, machine.Pin.OUT, value=0)
 
 # ─────────────────────────────────────────────
-# SC HELPERS
+# TRIGGER HELPERS
 # ─────────────────────────────────────────────
 def is_sc_trigger(name):
     return name is not None and name.startswith("SC:")
 
 def parse_sc_mac(name):
-    if not is_sc_trigger(name):
-        return None
+    if not is_sc_trigger(name): return None
     return name[3:]
 
 def is_gesture_trigger(name):
@@ -79,8 +83,7 @@ def is_gesture_trigger(name):
 # ─────────────────────────────────────────────
 # SCAN FEEDBACK
 # ─────────────────────────────────────────────
-def on_tag_detect(uid_hex, sak):
-    pass
+def on_tag_detect(uid_hex, sak): pass
 
 def on_scan_progress(frame):
     leds.scan_animate(frame)
@@ -108,102 +111,68 @@ def print_rules(rules, editing):
     for trig in TRIGGER_ORDER:
         marker = " *" if trig == editing else ""
         if trig in rules and len(rules[trig]) > 0:
-            print("  | %s -> [%s]%s" % (trig, chain_to_str(rules[trig]), marker))
-            has_any = True
+            print("  | %s -> [%s]%s" % (trig, chain_to_str(rules[trig]), marker)); has_any = True
         elif trig == editing:
             print("  | %s -> (awaiting actions)%s" % (trig, marker))
-
     for trig in sorted(rules.keys()):
         if is_gesture_trigger(trig):
-            gn = trig.split(":", 1)[1]
-            marker = " *" if trig == editing else ""
+            gn = trig.split(":", 1)[1]; marker = " *" if trig == editing else ""
             if len(rules[trig]) > 0:
-                print("  | gesture:%s -> [%s]%s" % (gn, chain_to_str(rules[trig]), marker))
-                has_any = True
+                print("  | gesture:%s -> [%s]%s" % (gn, chain_to_str(rules[trig]), marker)); has_any = True
             elif trig == editing:
                 print("  | gesture:%s -> (awaiting actions)%s" % (gn, marker))
-
     if is_gesture_trigger(editing) and editing not in rules:
         print("  | %s -> (awaiting actions) *" % editing)
-
     for trig in sorted(rules.keys()):
-        if is_sc_trigger(trig):
+        if is_sc_trigger(trig) or is_sp_trigger(trig):
             marker = " *" if trig == editing else ""
             if len(rules[trig]) > 0:
-                print("  | %s -> [%s]%s" % (trig, chain_to_str(rules[trig]), marker))
-                has_any = True
+                print("  | %s -> [%s]%s" % (trig, chain_to_str(rules[trig]), marker)); has_any = True
             elif trig == editing:
                 print("  | %s -> (awaiting actions)%s" % (trig, marker))
-
-    if is_sc_trigger(editing) and editing not in rules:
+    if (is_sc_trigger(editing) or is_sp_trigger(editing)) and editing not in rules:
         print("  | %s -> (awaiting actions) *" % editing)
-
     if not has_any and not editing:
         print("  | (empty -- tap a trigger tag)")
     print("  +----------------------------------------")
 
-
 # ─────────────────────────────────────────────
-# CHECK BROADCAST (used in multiple places)
+# CHECK BROADCAST
 # ─────────────────────────────────────────────
 def check_broadcast(mgr, batt_ref, leds_ref, buz_ref):
-    """
-    Poll ESP-NOW for broadcast stop/battery.
-    Returns "stop" if stop received, "battery" if battery shown, None otherwise.
-    """
     msg_type, data, mac_str = mgr.poll()
-    if msg_type == "stop":
-        return "stop"
+    if msg_type == "stop": return "stop"
     if msg_type == "battery":
-        show_battery(batt_ref, leds_ref, buz_ref)
-        return "battery"
+        show_battery(batt_ref, leds_ref, buz_ref); return "battery"
     return None
 
-
 # ─────────────────────────────────────────────
-# EVENT LOOP (RUNNING)
+# LOCAL EVENT LOOP (no SP)
 # ─────────────────────────────────────────────
 def run_event_loop(reader, rules, runner, accel_ref, ge_ref, mgr=None, batt_ref=None):
     btn_was_down = (btn.value() == 0)
-    if accel_ref and "shake" in rules:
-        accel_ref.clear_wake()
-
+    if accel_ref and "shake" in rules: accel_ref.clear_wake()
     gesture_last_fire = 0
     g_map = {}
     for tk in rules:
         if is_gesture_trigger(tk) and len(rules[tk]) > 0:
             g_map[tk.split(":", 1)[1]] = tk
     has_g = len(g_map) > 0
-
-    nfc_cnt = 0
-    espnow_cnt = 0
-
-    print("  Event loop active:")
-    for trig in sorted(rules.keys()):
-        if not is_sc_trigger(trig) and len(rules[trig]) > 0:
-            print("    %s -> [%s]" % (trig, chain_to_str(rules[trig])))
-
+    nfc_cnt = 0; espnow_cnt = 0
     while True:
-        fired = None
-        btn_down = (btn.value() == 0)
-
+        fired = None; btn_down = (btn.value() == 0)
         if btn_down and not btn_was_down:
             time.sleep_ms(30)
             if btn.value() == 0:
-                if "buttondown" in rules and len(rules["buttondown"]) > 0:
-                    fired = "buttondown"
+                if "buttondown" in rules and len(rules["buttondown"]) > 0: fired = "buttondown"
         elif not btn_down and btn_was_down:
             time.sleep_ms(30)
             if btn.value() == 1:
-                if "buttonup" in rules and len(rules["buttonup"]) > 0:
-                    fired = "buttonup"
+                if "buttonup" in rules and len(rules["buttonup"]) > 0: fired = "buttonup"
         btn_was_down = btn_down
-
         if fired is None and accel_ref and "shake" in rules and len(rules["shake"]) > 0:
             if int1_pin.value() == 1:
-                accel_ref.clear_wake(); time.sleep_ms(100); accel_ref.clear_wake()
-                fired = "shake"
-
+                accel_ref.clear_wake(); time.sleep_ms(100); accel_ref.clear_wake(); fired = "shake"
         if fired is None and ge_ref and has_g and ge_ref.loaded_gestures:
             now = time.ticks_ms()
             if time.ticks_diff(now, gesture_last_fire) > 800:
@@ -211,287 +180,210 @@ def run_event_loop(reader, rules, runner, accel_ref, ge_ref, mgr=None, batt_ref=
                     name, conf, dist, ad = ge_ref.capture_and_classify()
                     if name is not None and conf >= CONFIDENCE_THRESHOLD:
                         tk = g_map.get(name)
-                        if tk:
-                            fired = tk
-                    gesture_last_fire = time.ticks_ms()
-
+                        if tk: fired = tk; gesture_last_fire = now
         if fired:
-            chain = rules[fired]
-            print("  * %s -> [%s]" % (fired, chain_to_str(chain)))
-            runner.run_chain(chain)
-
-        # ESP-NOW broadcast check
-        if mgr and mgr.is_active:
-            espnow_cnt += 1
-            if espnow_cnt >= 5:
-                espnow_cnt = 0
-                result = check_broadcast(mgr, batt_ref, leds, buz)
-                if result == "stop":
-                    return
-                if result == "battery":
-                    leds.show_running(rules)
-
+            chain = rules.get(fired, [])
+            if chain: runner.run_chain(chain)
         nfc_cnt += 1
-        if nfc_cnt >= 15:
+        if nfc_cnt >= 5:
             nfc_cnt = 0
-            try:
-                cmd, _ = read_quiet(reader)
-                if cmd == "stop":
-                    return
-            except Exception:
-                pass
-
-        time.sleep_ms(20)
-
+            c2, _ = read_quiet(reader)
+            if c2 == "stop": return
+        espnow_cnt += 1
+        if espnow_cnt >= 3 and mgr:
+            espnow_cnt = 0
+            r2 = check_broadcast(mgr, batt_ref, leds, buz)
+            if r2 == "stop": return
+        time.sleep_ms(40)
 
 # ─────────────────────────────────────────────
 # MAIN
 # ─────────────────────────────────────────────
 def main():
     print("\n" + "=" * 50)
-    print("  PlaygroundV5 -- Multi-Trigger Event Engine")
+    print("  Wand — NFC Event Engine + Direct Splat BLE")
     print("  Hub type: %s" % HUB_TYPE)
     print("=" * 50)
 
-    # NFC
     nfc = PN532(i2c, PN532_ADDR)
-    try:
-        ic, ver, rev = nfc.begin()
-        print("  PN5%02X fw %d.%d -- NFC ready" % (ic, ver, rev))
-    except Exception as e:
-        print("  [FAIL] NFC:"); sys.print_exception(e); return
-
+    ic, ver, rev = nfc.begin()
+    print("  PN5%02X fw %d.%d" % (ic, ver, rev))
+    nfc._send_command(0x32, b'\x05\x01\x01\x02')
     reader = NfcReader(nfc, ALL_COMMANDS)
     runner = ActionRunner(leds, buz)
 
-    # ESP-NOW
-    mgr = ESPNowManager()
-    mgr.init()
-
-    # Accelerometer
-    accel = None
-    accel_ok = False
+    accel = None; accel_ok = False
     try:
-        accel = LIS2DW12(i2c)
-        accel.init(fs_range=RANGE_4G)
-        accel.enable_wake_int1(threshold=8)
-        accel_ok = True
+        accel = LIS2DW12(i2c); accel.init(odr_mode=0x54, fs_range=RANGE_4G)
+        accel.enable_wake_int1(threshold=8); accel.clear_wake(); accel_ok = True
         print("  Accelerometer OK")
-    except Exception as e:
-        print("  [WARN] Accel:"); sys.print_exception(e)
+    except Exception as e: print("  [WARN] Accelerometer:"); sys.print_exception(e)
 
-    # Gesture engine
-    ge = None
-    ge_ok = False
+    ge = None; ge_ok = False
     try:
-        from neopixel import NeoPixel as NP
-        ge_np = NP(machine.Pin(HUB_CONFIG["led_pin"]), HUB_CONFIG["num_leds"])
-        ge = GestureEngine(i2c, ge_np, buzzer_pin=BUZZER_PIN)
-        ge.init()
-        ge_ok = True
-        print("  Gesture engine OK")
-    except Exception as e:
-        print("  [WARN] Gesture engine:"); sys.print_exception(e)
+        ge = GestureEngine(i2c, leds.np, buzzer_pin=BUZZER_PIN, num_leds=HUB_CONFIG["num_leds"])
+        ge_ok = True; print("  Gesture engine OK")
+    except Exception as e: print("  [WARN] Gesture engine:"); sys.print_exception(e)
+    if ge_ok: reader.gesture_engine = ge
 
-    if ge_ok:
-        reader.gesture_engine = ge
-
-    # Battery
     batt = None
     try:
-        batt = MAX17048(i2c)
-        v, s = batt.read_all()
+        batt = MAX17048(i2c); v, s = batt.read_all()
         print("  Battery: %.2fV, %.1f%%" % (v, s))
-    except Exception as e:
-        print("  [WARN] Battery:"); sys.print_exception(e)
+    except Exception as e: print("  [WARN] Battery:"); sys.print_exception(e)
 
-    # ── State ──
-    rules = {}
-    editing = None
-    pending_combinator = None
-    last_uid = None
+    mgr = ESPNowManager(); mgr.init()
 
+    rules = {}; editing = None; pending_combinator = None; last_uid = None
     leds.show_programming(rules, editing)
     print("\n  Tap a TRIGGER tag to start programming\n")
 
     while True:
         try:
             uid_peek, sak_peek = reader.detect_tag()
-
             if uid_peek is None:
-                if last_uid is not None:
-                    last_uid = None
-                # Check broadcast while idle
+                if last_uid is not None: last_uid = None
                 result = check_broadcast(mgr, batt, leds, buz)
                 if result == "stop":
                     mgr.send_stop_all_peers(); mgr.clear_peers()
+                    sp_disconnect_all(leds, mgr)
                     rules = {}; editing = None; pending_combinator = None
                     if ge: ge.clear_loaded()
                     buz.stop(); leds.show_programming(rules, editing)
-                    print("  Reset via broadcast")
-                elif result == "battery":
-                    leds.show_programming(rules, editing)
-                time.sleep_ms(200)
-                continue
-
-            if uid_peek == last_uid:
+                elif result == "battery": leds.show_programming(rules, editing)
                 time.sleep_ms(200); continue
 
-            cmd, uid = read_with_feedback(reader)
-            last_uid = uid
-            if cmd is None:
-                time.sleep_ms(200); continue
+            if uid_peek == last_uid: time.sleep_ms(200); continue
+            cmd, uid = read_with_feedback(reader); last_uid = uid
+            if cmd is None: time.sleep_ms(200); continue
 
-            # ── SC TAG ──
             is_sc_cmd = False
             if cmd.startswith("sc:") and len(cmd) > 3:
-                cmd = "SC:" + cmd[3:].upper()
-                is_sc_cmd = True
+                cmd = "SC:" + cmd[3:].upper(); is_sc_cmd = True
+            is_sp_cmd = False
+            if cmd.startswith("sp:") and len(cmd) > 3:
+                cmd = "SP:" + cmd[3:].upper(); is_sp_cmd = True
 
-            # ── UTILITY ──
             if cmd == "battery":
-                show_battery(batt, leds, buz)
-                leds.show_programming(rules, editing); continue
-
-            # ── COLOR QUEST ──
+                show_battery(batt, leds, buz); leds.show_programming(rules, editing); continue
             if cmd == "colorquest":
-                leds.off()
-                play_color_quest(nfc, leds.np, buz)
+                leds.off(); sp_disconnect_all(leds, mgr); play_color_quest(nfc, leds.np, buz)
                 leds.show_programming(rules, editing); last_uid = None; continue
-
-            # ── FREEZE DANCE ──
             if cmd == "freezedance":
-                leds.off()
-                play_freeze_dance(nfc, leds, buz, accel, i2c)
+                leds.off(); sp_disconnect_all(leds, mgr); play_freeze_dance(nfc, leds, buz, accel, i2c)
                 leds.show_programming(rules, editing); last_uid = None; continue
-
-            # ── GESTURE TAG ──
             if cmd.startswith("gesture:"):
-                if not ge_ok:
-                    buz.warn(); continue
-                editing = cmd; pending_combinator = None
-                buz.confirm()
+                if not ge_ok: buz.warn(); continue
+                editing = cmd; pending_combinator = None; buz.confirm()
                 print_rules(rules, editing); leds.show_programming(rules, editing); continue
-
-            # ── SC TAG ──
             if is_sc_cmd:
-                sc_mac = parse_sc_mac(cmd)
+                sc_mac = parse_sc_mac(cmd); editing = cmd; pending_combinator = None
+                mgr.add_peer(sc_mac); buz.confirm(); leds.flash(0, 15, 15, times=2, on_ms=80, off_ms=60)
+                print_rules(rules, editing); leds.show_programming(rules, editing); continue
+            if is_sp_cmd:
                 editing = cmd; pending_combinator = None
-                mgr.add_peer(sc_mac)
                 buz.confirm(); leds.flash(0, 15, 15, times=2, on_ms=80, off_ms=60)
-                print("  > Splat Companion: %s" % sc_mac)
+                print("  > Direct Splat: %s (BLE deferred to start)" % parse_sp_mac(cmd))
                 print_rules(rules, editing); leds.show_programming(rules, editing); continue
 
             print("  >> %s" % cmd)
 
-            # ── FIXED TRIGGER ──
             if cmd in FIXED_TRIGGERS:
-                if cmd == "shake" and not accel_ok:
-                    buz.warn(); continue
-                editing = cmd; pending_combinator = None
-                buz.confirm()
+                if cmd == "shake" and not accel_ok: buz.warn(); continue
+                editing = cmd; pending_combinator = None; buz.confirm()
                 print_rules(rules, editing); leds.show_programming(rules, editing)
-
-            # ── ACTION ──
             elif cmd in ACTIONS or cmd in ANIMAL_SOUNDS:
-                if editing is None:
-                    buz.reject(); continue
+                if editing is None: buz.reject(); continue
                 chain = rules.get(editing, [])
                 if pending_combinator == "and" and len(chain) > 0:
-                    chain[-1].append(cmd)
-                    chain[-1] = resolve_and_group(chain[-1])
+                    chain[-1].append(cmd); chain[-1] = resolve_and_group(chain[-1])
                     rules[editing] = chain; pending_combinator = None
                 elif pending_combinator == "then" and len(chain) > 0:
-                    chain.append([cmd])
-                    rules[editing] = chain; pending_combinator = None
-                else:
-                    rules[editing] = [[cmd]]
-                buz.confirm()
-                print_rules(rules, editing); leds.show_programming(rules, editing)
-
-            # ── COMBINATORS ──
+                    chain.append([cmd]); rules[editing] = chain; pending_combinator = None
+                else: rules[editing] = [[cmd]]
+                buz.confirm(); print_rules(rules, editing); leds.show_programming(rules, editing)
             elif cmd == "and":
-                if editing is None or editing not in rules or len(rules[editing]) == 0:
-                    buz.beep(200, 150)
-                else:
-                    pending_combinator = "and"
-                    buz.beep(500, 40); time.sleep_ms(30); buz.beep(500, 40)
-
+                if editing is None or editing not in rules or len(rules[editing]) == 0: buz.beep(200, 150)
+                else: pending_combinator = "and"; buz.beep(500, 40); time.sleep_ms(30); buz.beep(500, 40)
             elif cmd == "then":
-                if editing is None or editing not in rules or len(rules[editing]) == 0:
-                    buz.beep(200, 150)
-                else:
-                    pending_combinator = "then"
-                    buz.beep(400, 60); time.sleep_ms(50); buz.beep(600, 60)
+                if editing is None or editing not in rules or len(rules[editing]) == 0: buz.beep(200, 150)
+                else: pending_combinator = "then"; buz.beep(400, 60); time.sleep_ms(50); buz.beep(600, 60)
 
-            # ── START ──
             elif cmd == "start":
-                if pending_combinator:
-                    buz.beep(200, 150); continue
-
+                if pending_combinator: buz.beep(200, 150); continue
                 active = {t: c for t, c in rules.items() if c and len(c) > 0}
-                if not active:
-                    buz.reject(); continue
+                if not active: buz.reject(); continue
 
-                # Send configs to Splat Companions
-                sc_rules = {}; local_rules = {}
+                sc_rules = {}; sp_rules = {}; local_rules = {}
                 for tk, ch in active.items():
-                    if is_sc_trigger(tk):
-                        sc_rules[tk] = ch
-                    else:
-                        local_rules[tk] = ch
+                    if is_sc_trigger(tk): sc_rules[tk] = ch
+                    elif is_sp_trigger(tk): sp_rules[tk] = ch
+                    else: local_rules[tk] = ch
+
+                has_sp = len(sp_rules) > 0
 
                 for tk, ch in sc_rules.items():
                     sc_mac = parse_sc_mac(tk)
-                    print("  Sending config to %s: [%s]" % (sc_mac, chain_to_str(ch)))
-                    mgr.send_splat_config(sc_mac, ch)
-                    time.sleep_ms(50)
+                    mgr.send_splat_config(sc_mac, ch); time.sleep_ms(50)
 
-                leds.off(); buz.start()
-                leds.flash(0, 40, 0, times=3, on_ms=80, off_ms=60)
-                if local_rules:
-                    leds.show_running(local_rules)
+                if has_sp:
+                    leds.solid(0, 0, 15)
+                    for tk, ch in sp_rules.items():
+                        sp_mac = parse_sp_mac(tk)
+                        splat, ctrl = sp_connect(sp_mac, leds, mgr)
+                        if splat is None: continue
+                        ctrl.set_config(ch)
+                        print("  SP config to %s: [%s]" % (sp_mac, chain_to_str(ch)))
 
-                total = len(local_rules) + len(sc_rules)
-                print("\n  >>> RUNNING %d rule(s) (%d local, %d remote)\n" % (total, len(local_rules), len(sc_rules)))
+                leds.off(); buz.start(); leds.flash(0, 40, 0, times=3, on_ms=80, off_ms=60)
+                if local_rules: leds.show_running(local_rules)
 
-                if local_rules:
+                total = len(local_rules) + len(sc_rules) + len(sp_rules)
+                print("\n  >>> RUNNING %d rule(s) (%d local, %d SC, %d SP)\n" % (
+                    total, len(local_rules), len(sc_rules), len(sp_rules)))
+
+                if has_sp:
+                    run_sp_loop(reader, leds, buz, btn, int1_pin,
+                                mgr, batt, check_broadcast, read_quiet,
+                                local_rules=local_rules if local_rules else None,
+                                runner=runner if local_rules else None,
+                                accel_ref=accel, ge_ref=ge)
+                    espnow_resume(mgr)
+                elif local_rules:
                     run_event_loop(reader, local_rules, runner, accel, ge, mgr=mgr, batt_ref=batt)
                 else:
-                    print("  (Only remote. Tap STOP to end)")
                     while True:
                         try:
                             c2, _ = read_quiet(reader)
                             if c2 == "stop": break
-                        except Exception:
-                            pass
+                        except Exception: pass
                         r2 = check_broadcast(mgr, batt, leds, buz)
                         if r2 == "stop": break
                         time.sleep_ms(200)
 
                 mgr.send_stop_all_peers()
+                for key, entry in sp_get_connections().items():
+                    try: entry["ctrl"].clear_config()
+                    except Exception: pass
+                    sp_signal_idle(entry)
                 rules = {}; editing = None; pending_combinator = None; last_uid = None
                 mgr.clear_peers()
                 if ge: ge.clear_loaded()
                 leds.off(); buz.stop(); leds.show_programming(rules, editing)
                 print("  <<< STOPPED\n  Tap a TRIGGER tag to reprogram\n")
 
-            # ── STOP ──
             elif cmd == "stop":
                 mgr.send_stop_all_peers(); mgr.clear_peers()
+                sp_disconnect_all(leds, mgr)
                 rules = {}; editing = None; pending_combinator = None
                 if ge: ge.clear_loaded()
                 buz.stop(); leds.show_programming(rules, editing)
-
-            else:
-                buz.beep(200, 150)
+            else: buz.beep(200, 150)
 
         except KeyboardInterrupt:
-            mgr.shutdown(); leds.off(); break
+            sp_disconnect_all(leds, mgr); mgr.shutdown(); leds.off(); break
         except Exception as e:
-            print("  [ERR]:"); sys.print_exception(e)
-            time.sleep_ms(500)
-
+            print("  [ERR]:"); sys.print_exception(e); time.sleep_ms(500)
 
 if __name__ == "__main__":
     main()

--- a/Bag2/Code/Wand Module/sp_loop.py
+++ b/Bag2/Code/Wand Module/sp_loop.py
@@ -1,0 +1,104 @@
+"""
+sp_loop.py — BLE-Primary Running Loop (v4)
+=============================================
+Split from the working unified main.py.
+"""
+
+_VERSION = "v4"
+
+import time
+from gesture_engine import CONFIDENCE_THRESHOLD
+from actions import chain_to_str
+from ble_splat_ctrl import (
+    is_sp_trigger, sp_keepalive_all,
+    sp_process_pending_all, espnow_quick_check,
+)
+
+
+def is_gesture_trigger(name):
+    return name is not None and name.startswith("gesture:")
+
+
+def run_sp_loop(reader, leds, buz, btn, int1_pin,
+                mgr, batt_ref,
+                check_broadcast_fn, read_quiet_fn,
+                local_rules=None, runner=None,
+                accel_ref=None, ge_ref=None):
+    last_ka = time.ticks_ms()
+    last_espnow_check = time.ticks_ms()
+    frame = 0
+
+    has_local = local_rules is not None and len(local_rules) > 0
+    btn_was_down = (btn.value() == 0)
+    gesture_last_fire = 0
+    g_map = {}
+    if has_local:
+        if accel_ref and "shake" in local_rules: accel_ref.clear_wake()
+        for tk in local_rules:
+            if is_gesture_trigger(tk) and len(local_rules[tk]) > 0:
+                g_map[tk.split(":", 1)[1]] = tk
+    has_g = len(g_map) > 0
+    nfc_cnt = 0
+
+    while True:
+        try:
+            now = time.ticks_ms()
+
+            if time.ticks_diff(now, last_ka) >= 2500:
+                sp_keepalive_all(); last_ka = now
+
+            sp_process_pending_all()
+
+            if has_local:
+                fired = None; btn_down = (btn.value() == 0)
+                if btn_down and not btn_was_down:
+                    time.sleep_ms(30)
+                    if btn.value() == 0:
+                        if "buttondown" in local_rules and len(local_rules["buttondown"]) > 0:
+                            fired = "buttondown"
+                elif not btn_down and btn_was_down:
+                    time.sleep_ms(30)
+                    if btn.value() == 1:
+                        if "buttonup" in local_rules and len(local_rules["buttonup"]) > 0:
+                            fired = "buttonup"
+                btn_was_down = btn_down
+                if fired is None and accel_ref and "shake" in local_rules and len(local_rules["shake"]) > 0:
+                    if int1_pin.value() == 1:
+                        accel_ref.clear_wake(); time.sleep_ms(100); accel_ref.clear_wake()
+                        fired = "shake"
+                if fired is None and ge_ref and has_g and ge_ref.loaded_gestures:
+                    if time.ticks_diff(now, gesture_last_fire) > 800:
+                        if ge_ref.poll_motion():
+                            name, conf, dist, ad = ge_ref.capture_and_classify()
+                            if name is not None and conf >= CONFIDENCE_THRESHOLD:
+                                tk = g_map.get(name)
+                                if tk: fired = tk; gesture_last_fire = now
+                if fired and runner:
+                    chain = local_rules.get(fired, [])
+                    if chain:
+                        print("  FIRE: %s -> [%s]" % (fired, chain_to_str(chain)))
+                        runner.run_chain(chain)
+
+            nfc_cnt += 1
+            if nfc_cnt >= 5:
+                nfc_cnt = 0
+                c2, _ = read_quiet_fn(reader)
+                if c2 == "stop":
+                    print("  STOP tag scanned"); return
+
+            if time.ticks_diff(now, last_espnow_check) >= 3000:
+                last_espnow_check = now
+                r2 = espnow_quick_check(mgr, check_broadcast_fn, batt_ref, leds, buz)
+                if r2 == "stop":
+                    print("  Stop via broadcast"); return
+
+            if not has_local and frame % 3 == 0:
+                leds.breathe(15, 0, 15, frame)
+            frame += 1
+            time.sleep_ms(40)
+        except KeyboardInterrupt: return
+        except Exception as e:
+            print("  [ERR] SP loop: %s" % str(e)); time.sleep_ms(500)
+
+
+print("[sp_loop %s loaded]" % _VERSION)

--- a/Bag2/Code/lib/ble_splat.py
+++ b/Bag2/Code/lib/ble_splat.py
@@ -1,0 +1,495 @@
+"""
+ble_splat.py — BLE driver for Open Splat devices
+==================================================
+v2: Write pacing, response capture, WRITE_DONE status tracking,
+always-on error logging. Button debouncing.
+"""
+
+import ubluetooth
+import time
+import struct
+import binascii
+import micropython
+
+
+UUID_SERVICE = ubluetooth.UUID(0xfff0)
+UUID_CHARACTERISTIC_RECV = ubluetooth.UUID(0xfff4)
+UUID_CHARACTERISTIC_WRITE = ubluetooth.UUID(0xfff3)
+
+
+# Command constants
+KEEP_ALIVE = 0x01, 0x00
+SOUND_OFF = 0x02, 0x00
+ALL_LEDS_OFF = 0x03, 0x00
+ALL_TASKS_OFF = 0x04, 0x00
+READ_SWITCHES = 0x05, 0x00
+READ_BATTERY = 0x06, 0x00
+IDENTIFY_SPLAT = 0x00, 0x10
+SET_VOLUME = 0x01, 0x10
+PLAY_SOUND = 0x00, 0x20
+PLAY_RECORDED_SOUND = 0x01, 0x20
+LEDS_OFF = 0x04, 0x20
+SET_LEDS = 0x01, 0x50
+PLAY_LED_SEQUENCE = 0x01, 0x60
+FLASH_LEDS = 0x01, 0x70
+NOTE_ON = 0x00, 0x40
+NOTE_OFF = 0x01, 0x40
+
+# Button debounce
+_DEBOUNCE_MS = 80
+
+# Minimum ms between BLE writes to let Splat process each command
+_WRITE_PACE_MS = 20
+
+# Max response notifications to keep in ring buffer
+_RESPONSE_BUF_SIZE = 8
+
+
+class OpenSplat():
+    def __init__(self, mac_address=None, verbose=False):
+        self._ble = ubluetooth.BLE()
+        self._ble.active(True)
+
+        self.mac_address = mac_address
+
+        self._connection = None
+        self._conn_handle = None
+        self._tx_char_handle = None
+        self._rx_char_handle = None
+
+        self._device_info = {}
+        self._date_time = None
+        self._time_schedule = []
+
+        self.on_splat_pressed = None
+        self.on_splat_released = None
+
+        self.sound = 1
+        self.volume = 255
+
+        # Set up IRQ handler
+        self._ble.irq(self._irq_handler)
+
+        # Connection state
+        self.connected = False
+        self._addr_type = None
+        self.addr = None
+        self.target_addr = None
+        self.device_name = None
+        self._value_handle = None
+        self._start_handle = None
+        self._end_handle = None
+        self._verbose = verbose
+        self._connecting = None
+        self._scanning = False
+
+        # Button state with debounce
+        self.splat_pressed = False
+        self._last_button_change_ms = 0
+        self._last_raw_state = False
+
+        # Write tracking
+        self._last_write_ms = 0
+        self._last_write_status = 0
+        self._write_count = 0
+        self._write_errors = 0
+
+        # Response capture — ring buffer of recent notifications
+        self._responses = []
+        self._capture_responses = False
+
+    def _irq_handler(self, event, data):
+        """Handle BLE IRQ events"""
+        if event == 1:  # _IRQ_CENTRAL_CONNECT
+            conn_handle, addr_type, addr = data
+            self._conn_handle = conn_handle
+            self.connected = True
+            if self._verbose:
+                print("Connected as central")
+
+        elif event == 2:  # _IRQ_CENTRAL_DISCONNECT
+            self._reset_connection_state()
+            if self._verbose:
+                print("Disconnected")
+
+        elif event == 5:  # _IRQ_SCAN_RESULT
+            self._addr_type, self.addr, adv_type, rssi, adv_data = data
+            self.device_name = self._parse_adv_name(adv_data)
+            self.target_addr = ':'.join(['%02X' % i for i in self.addr])
+
+            if self.target_addr == self.mac_address and not self._connecting:
+                self._ble.gap_scan(None)
+                self._scanning = False
+                self._connecting = True
+                try:
+                    self._ble.gap_connect(self._addr_type, self.addr)
+                    if self._verbose:
+                        print("Connecting...")
+                except Exception as e:
+                    print("Connection failed: %s" % str(e))
+                    self._connecting = False
+
+            elif self.device_name == 'Splat' and not self._connecting:
+                self.mac_address = self.target_addr
+                self._ble.gap_scan(None)
+                self._scanning = False
+
+        elif event == 6:  # _IRQ_SCAN_DONE
+            self._scanning = False
+            if self._verbose:
+                print("Scan complete")
+
+        elif event == 7:  # _IRQ_PERIPHERAL_CONNECT
+            conn_handle, addr_type, addr = data
+            addr_str = ':'.join(['%02X' % i for i in addr])
+
+            if addr_str == self.mac_address:
+                self._conn_handle = conn_handle
+                self.connected = True
+                self._connecting = False
+                if self._verbose:
+                    print("Connected! Discovering services...")
+                self._ble.gattc_discover_services(self._conn_handle)
+
+        elif event == 8:  # _IRQ_PERIPHERAL_DISCONNECT
+            self._reset_connection_state()
+            if self._verbose:
+                print("Peripheral disconnected")
+
+        elif event == 9:  # _IRQ_GATTC_SERVICE_RESULT
+            conn_handle, start_handle, end_handle, uuid = data
+            if uuid == UUID_SERVICE:
+                self._start_handle = start_handle
+                self._end_handle = end_handle
+                if self._verbose:
+                    print("Service found: %d-%d" % (start_handle, end_handle))
+
+        elif event == 10:  # _IRQ_GATTC_SERVICE_DONE
+            if self._start_handle and self._end_handle:
+                self._ble.gattc_discover_characteristics(
+                    self._conn_handle, self._start_handle, self._end_handle
+                )
+            else:
+                print("Required service not found")
+
+        elif event == 11:  # _IRQ_GATTC_CHARACTERISTIC_RESULT
+            conn_handle, def_handle, value_handle, properties, uuid = data
+            if uuid == UUID_CHARACTERISTIC_WRITE:
+                self._tx_char_handle = value_handle
+            elif uuid == UUID_CHARACTERISTIC_RECV:
+                self._rx_char_handle = value_handle
+
+        elif event == 12:  # _IRQ_GATTC_CHARACTERISTIC_DONE
+            if self._rx_char_handle:
+                self._subscribe_to_notifications()
+            if self._verbose:
+                print("Setup complete!")
+
+        elif event == 17:  # _IRQ_GATTC_WRITE_DONE
+            conn_handle, value_handle, status = data
+            self._last_write_status = status
+            if status != 0:
+                self._write_errors += 1
+                print("  BLE write error: status=%d (errs=%d/%d)" % (
+                    status, self._write_errors, self._write_count))
+
+        elif event == 18:  # _IRQ_GATTC_NOTIFY
+            conn_handle, value_handle, notify_data = data
+            if value_handle == self._rx_char_handle:
+                self._process_notification(notify_data)
+
+    def _parse_adv_name(self, adv_data):
+        i = 0
+        while i < len(adv_data):
+            length = adv_data[i]
+            if length == 0:
+                break
+            ad_type = adv_data[i + 1]
+            if ad_type == 0x09 or ad_type == 0x08:
+                name_bytes = adv_data[i + 2:i + 1 + length]
+                try:
+                    return bytes(name_bytes).decode('utf-8')
+                except:
+                    return None
+            i += 1 + length
+        return None
+
+    def _reset_connection_state(self):
+        self.connected = False
+        self._conn_handle = None
+        self._connecting = False
+        self._tx_char_handle = None
+        self._rx_char_handle = None
+        self._start_handle = None
+        self._end_handle = None
+
+    def _process_notification(self, buffer):
+        """Process notifications from the Splat device."""
+        raw = bytes(buffer)
+
+        # Capture all responses when enabled
+        if self._capture_responses:
+            if len(self._responses) >= _RESPONSE_BUF_SIZE:
+                self._responses.pop(0)
+            self._responses.append(raw)
+
+        if len(buffer) >= 11 and buffer[0] == 0x66 and buffer[11] == 0x99:
+            if self._verbose:
+                value = ':'.join(['%02X' % i for i in buffer])
+                print("Device info: %s" % value)
+
+        elif len(buffer) >= 10 and buffer[0] == 0x13 and buffer[10] == 0x31:
+            if self._verbose:
+                print("Received date/time")
+
+        else:
+            data = [d for d in buffer]
+            # Button state notification: [3, X, button_byte]
+            if data[0] == 3 and len(data) == 3:
+                self._handle_button(data[2])
+            elif self._verbose:
+                print("Notification: %s" % ' '.join('%02X' % b for b in data))
+
+    def _handle_button(self, value):
+        now = time.ticks_ms()
+        raw_pressed = bool(value & 0x0F)
+        
+        print("  [BTN raw=%d pressed=%s last_raw=%s]" % (value, raw_pressed, self._last_raw_state))
+
+        if raw_pressed == self._last_raw_state:
+            return
+        self._last_raw_state = raw_pressed
+
+        if time.ticks_diff(now, self._last_button_change_ms) < _DEBOUNCE_MS:
+            print("  [BTN debounce rejected]")
+            return
+        self._last_button_change_ms = now
+
+        was_pressed = self.splat_pressed
+        print("  [BTN was=%s raw=%s cb=%s]" % (was_pressed, raw_pressed, self.on_splat_pressed is not None))
+
+        if raw_pressed and not was_pressed:
+            self.splat_pressed = True
+            if self.on_splat_pressed:
+                try:
+                    self.on_splat_pressed()
+                except Exception as e:
+                    print("  Press callback error: %s" % str(e))
+
+        elif not raw_pressed and was_pressed:
+            self.splat_pressed = False
+            if self.on_splat_released:
+                try:
+                    self.on_splat_released()
+                except Exception as e:
+                    print("  Release callback error: %s" % str(e))
+
+    def decode_button(self, value):
+        self._handle_button(value)
+
+    def _subscribe_to_notifications(self):
+        if self._rx_char_handle:
+            try:
+                self._ble.gattc_write(
+                    self._conn_handle, self._rx_char_handle + 1, b'\x01\x00'
+                )
+                if self._verbose:
+                    print("Subscribed to notifications")
+            except Exception as e:
+                print("Subscription failed: %s" % str(e))
+
+    def _write_command(self, data):
+        """Write command with pacing."""
+        if not self.connected or self._tx_char_handle is None:
+            if self._verbose:
+                print("Not connected or TX characteristic not found")
+            return False
+
+        now = time.ticks_ms()
+        elapsed = time.ticks_diff(now, self._last_write_ms)
+        if elapsed < _WRITE_PACE_MS:
+            time.sleep_ms(_WRITE_PACE_MS - elapsed)
+
+        try:
+            self._ble.gattc_write(self._conn_handle, self._tx_char_handle, data)
+            self._last_write_ms = time.ticks_ms()
+            self._write_count += 1
+            if self._verbose:
+                print("Sent: %s" % ' '.join('%02X' % b for b in data))
+            return True
+        except Exception as e:
+            print("Send error: %s" % str(e))
+            return False
+
+    # ── Response capture ──
+
+    def start_capture(self):
+        """Start capturing all notification responses."""
+        self._responses = []
+        self._capture_responses = True
+
+    def stop_capture(self):
+        """Stop capturing responses."""
+        self._capture_responses = False
+
+    def get_responses(self, clear=True):
+        """Get captured responses. Returns list of bytes objects."""
+        r = list(self._responses)
+        if clear:
+            self._responses = []
+        return r
+
+    def dump_responses(self, label=""):
+        """Print all captured responses in hex."""
+        resps = self.get_responses()
+        if label:
+            print("  Responses after [%s]: %d" % (label, len(resps)))
+        else:
+            print("  Responses: %d" % len(resps))
+        for i, r in enumerate(resps):
+            print("    [%d] (%d bytes) %s" % (i, len(r), ' '.join('%02X' % b for b in r)))
+        return resps
+
+    # ── Send + wait for response ──
+
+    def send_and_wait(self, data, label="", wait_ms=300):
+        """
+        Send a command and wait for the Splat's response notification.
+        Returns list of response bytes objects received.
+        """
+        self.start_capture()
+        ba = bytearray(data)
+        ok = self._write_command(ba)
+        if label:
+            print("    [%s] %s -> %s" % (label, ' '.join('%02X' % b for b in ba), "OK" if ok else "FAIL"))
+        time.sleep_ms(wait_ms)
+        self.stop_capture()
+        return self.dump_responses(label)
+
+    # ── Scanning / Connection ──
+
+    def scanSplat(self, timeout=5):
+        print("Scanning for Splat...")
+        self._reset_connection_state()
+        self._scanning = True
+        self._ble.gap_scan(0, 1000, 1000)
+        start = time.time()
+        while self._scanning and (time.time() - start < timeout):
+            time.sleep(0.1)
+        if self._scanning:
+            self._ble.gap_scan(None)
+            self._scanning = False
+        return self.mac_address
+
+    def connect(self, timeout=30):
+        self._ble.active(True)
+        if self.connected:
+            return True
+        self._reset_connection_state()
+        self._scanning = True
+        self._ble.gap_scan(0, 30000, 30000)
+        start_time = time.time()
+        while not self.connected and (time.time() - start_time < timeout):
+            if not self._scanning and not self._connecting:
+                self._scanning = True
+                self._ble.gap_scan(0, 30000, 30000)
+            print(".", end="")
+            time.sleep(0.5)
+        if self._scanning:
+            self._ble.gap_scan(None)
+            self._scanning = False
+        if not self.connected:
+            print("\nConnection timeout after %ds" % timeout)
+            return False
+        start_time = time.time()
+        while (not self._tx_char_handle or not self._rx_char_handle) and (time.time() - start_time < 10):
+            time.sleep(0.5)
+        if not self._tx_char_handle or not self._rx_char_handle:
+            print("\nService setup failed")
+            self.disconnect()
+            return False
+        print("\nConnected successfully!")
+        return True
+
+    def disconnect(self):
+        if self._conn_handle is not None:
+            self._ble.gap_disconnect(self._conn_handle)
+            self._conn_handle = None
+            self.connected = False
+            if self._verbose:
+                print("Disconnected from Splat")
+            self._ble.active(False)
+
+    def is_connected(self):
+        return self.connected
+
+    # ── Command implementations ──
+
+    def keepAlive(self):
+        return self._write_command(bytearray(KEEP_ALIVE))
+
+    def soundOff(self):
+        return self._write_command(bytearray(SOUND_OFF))
+
+    def allLEDsOff(self):
+        return self._write_command(bytearray(ALL_LEDS_OFF))
+
+    def allTasksOff(self):
+        return self._write_command(bytearray(ALL_TASKS_OFF))
+
+    def readSwitches(self):
+        return self._write_command(bytearray(READ_SWITCHES))
+
+    def readBattery(self):
+        return self._write_command(bytearray(READ_BATTERY))
+
+    def identifySplat(self):
+        return self._write_command(bytearray(IDENTIFY_SPLAT))
+
+    def setVolume(self, vol):
+        return self._write_command(bytearray(SET_VOLUME + (vol,)))
+
+    def playSound(self, soundIndex, vol):
+        return self._write_command(bytearray(PLAY_SOUND + (soundIndex, vol)))
+
+    def playRecordedSound(self, soundIndex, vol):
+        return self._write_command(bytearray(PLAY_RECORDED_SOUND + (soundIndex, vol)))
+
+    def LEDsOff(self, lowByte, highByte):
+        return self._write_command(bytearray(LEDS_OFF + (lowByte, highByte)))
+
+    def setLEDsON(self, color):
+        return self._write_command(bytearray(
+            SET_LEDS + (0xFF, 0x3F, color[0], color[1], color[2])
+        ))
+
+    def setLEDs(self, leds, red, green, blue):
+        value = 0
+        for led in leds:
+            value = value | 1 << led
+        return self._write_command(bytearray(
+            SET_LEDS + (value & 0xFF, value >> 8 & 0xFF, red, green, blue)
+        ))
+
+    def playLEDSequence(self, seqIndex, red, green, blue, duration, loops):
+        return self._write_command(bytearray(
+            PLAY_LED_SEQUENCE + (seqIndex, red, green, blue, duration, loops)
+        ))
+
+    def flashLEDs(self, lowByte, highByte, red, green, blue, duration, flashes):
+        return self._write_command(bytearray(
+            FLASH_LEDS + (lowByte, highByte, red, green, blue, duration, flashes)
+        ))
+
+    def noteOn(self, note, velocity, octave, instrument):
+        return self._write_command(bytearray(
+            NOTE_ON + (note, octave, velocity, instrument)
+        ))
+
+    def noteOff(self, note, velocity, octave, instrument):
+        return self._write_command(bytearray(
+            NOTE_OFF + (note, octave, velocity, instrument)
+        ))
+
+    def write_stats(self):
+        return "writes=%d errors=%d" % (self._write_count, self._write_errors)


### PR DESCRIPTION
Now wand can directly control the Splats . The Splats will need NFC tag with SP:<MAC> in the format SP:XX:XX:XX:XX:XX:XX . wand detects the tag with SP and identifies it as a trigger. 