### PR TITLE
Add wand icon reference card

### DIFF
--- a/Live_Page/index.html
+++ b/Live_Page/index.html
@@ -180,6 +180,12 @@
                 <h2>Code Upload</h2>
                 <p>Upload code to your ESP32C6 device</p>
             </a>
+
+            <a href="wand_icons.html" class="button-card">
+                <div class="icon">🪄</div>
+                <h2>Wand Icon Reference</h2>
+                <p>Look up the meaning of wand icons</p>
+            </a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
Insert a new button-card in Live_Page/index.html linking to wand_icons.html. The card includes a wand emoji icon, title 'Wand Icon Reference', and a short description to let users look up the meaning of wand icons.