### PR TITLE
Add favicons and update WebApp manifest icons

### DIFF
--- a/Live_Page/Code_Upload/index.html
+++ b/Live_Page/Code_Upload/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="../icon/cropped-Icon-1-32x32.png" sizes="32x32"/>
+  <link rel="icon" href="../icon/cropped-Icon-1-192x192.png" sizes="192x192"/>
+  <link rel="apple-touch-icon" href="../icon/cropped-Icon-1-180x180.png"/>
+  <meta name="msapplication-TileImage" content="../icon/cropped-Icon-1-270x270.png"/>
   <title>ESP32 Code Uploader</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/Live_Page/If_Splats/index.html
+++ b/Live_Page/If_Splats/index.html
@@ -5,6 +5,10 @@
     <!-- Recommended meta tags -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="icon" href="../icon/cropped-Icon-1-32x32.png" sizes="32x32"/>
+    <link rel="icon" href="../icon/cropped-Icon-1-192x192.png" sizes="192x192"/>
+    <link rel="apple-touch-icon" href="../icon/cropped-Icon-1-180x180.png"/>
+    <meta name="msapplication-TileImage" content="../icon/cropped-Icon-1-270x270.png"/>
     <!-- PyScript CSS -->
     <link rel="stylesheet" href="https://pyscript.net/releases/2026.2.1/core.css">
     <!-- This script tag bootstraps PyScript -->

--- a/Live_Page/Wand Pages/student-guide.html
+++ b/Live_Page/Wand Pages/student-guide.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="../icon/cropped-Icon-1-32x32.png" sizes="32x32"/>
+<link rel="icon" href="../icon/cropped-Icon-1-192x192.png" sizes="192x192"/>
+<link rel="apple-touch-icon" href="../icon/cropped-Icon-1-180x180.png"/>
+<meta name="msapplication-TileImage" content="../icon/cropped-Icon-1-270x270.png"/>
 <title>Color Quest — How to Play</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;700;800&display=swap');

--- a/Live_Page/WebApp/index.html
+++ b/Live_Page/WebApp/index.html
@@ -32,6 +32,10 @@ Browser Requirements:
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="mobile-web-app-capable" content="yes">
+    <link rel="icon" href="../icon/cropped-Icon-1-32x32.png" sizes="32x32"/>
+    <link rel="icon" href="../icon/cropped-Icon-1-192x192.png" sizes="192x192"/>
+    <link rel="apple-touch-icon" href="../icon/cropped-Icon-1-180x180.png"/>
+    <meta name="msapplication-TileImage" content="../icon/cropped-Icon-1-270x270.png"/>
     <title>Smart Playground Control</title>
     <link rel="manifest" href="manifest.json">
     

--- a/Live_Page/WebApp/manifest.json
+++ b/Live_Page/WebApp/manifest.json
@@ -8,14 +8,14 @@
     "theme_color": "#3b82f6",
     "icons": [
         {
-            "src": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTkyIiBoZWlnaHQ9IjE5MiIgdmlld0JveD0iMCAwIDE5MiAxOTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIxOTIiIGhlaWdodD0iMTkyIiByeD0iMjQiIGZpbGw9IiMzYjgyZjYiLz4KPHBhdGggZD0iTTk2IDQ4QzEwOC4yODQgNDggMTE4IDU3LjcxNiAxMTggNzBWNzJIMTIyQzEzNC4yODQgMTIyIDEyMiAxMzEuNzE2IDEyMiAxNDRIMTIyQzEwOS43MTYgMTQ0IDEwMCAxMzQuMjg0IDEwMCAxMjJIMTAwQzg3LjcxNiAxMjIgNzggMTEyLjI4NCA3OCAxMDBINzRDNjEuNzE2IDEwMCA1MiAxMDkuNzE2IDUyIDEyMkg1MkM1MiAxMzQuMjg0IDYxLjcxNiAxNDQgNzQgMTQ0SDc0Qzg2LjI4NCAxNDQgOTYgMTM0LjI4NCA5NiAxMjJINjRDNjQgMTA5LjcxNiA3My43MTYgMTAwIDg2IDEwMEg5NlY0OFoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=",
+            "src": "../icon/cropped-Icon-1-192x192.png",
             "sizes": "192x192",
-            "type": "image/svg+xml"
+            "type": "image/png"
         },
         {
-            "src": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgdmlld0JveD0iMCAwIDUxMiA1MTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIiByeD0iNjQiIGZpbGw9IiMzYjgyZjYiLz4KPHBhdGggZD0iTTI1NiAxMjhDMjI4LjNzIDEyOCAyMDggMTQ4LjMgMjA4IDE3NlYxOTJIMjI0QzI5Ni4zcyAyMjQgMzE2IDI0NCAzNDRIMjQ0QzIxNi4zIDM0NCAxOTYgMzIzLjcgMTk2IDI5NkgyMDBDMjAwIDI2OC4zIDIyOC4zIDI0MCAyNTYgMjQwSDI3MkMyNzIgMjY4LjMgMzAwLjMgMjk2IDMyOCAyOTZIMzM2QzMzNiAzMjMuNyAzMTUuNyAzNDQgMjg4IDM0NEgyODhDMzE1LjcgMzQ0IDMzNiAzMjMuNyAzMzYgMjk2SDI3MkMyNzIgMjY4LjMgMzAwLjMgMjQwIDMyOCAyNDBIMjU2VjEyOFoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=",
-            "sizes": "512x512",
-            "type": "image/svg+xml"
+            "src": "../icon/cropped-Icon-1-270x270.png",
+            "sizes": "270x270",
+            "type": "image/png"
         }
     ]
 }

--- a/Live_Page/wand_icons.html
+++ b/Live_Page/wand_icons.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="icon" href="icon/cropped-Icon-1-32x32.png" sizes="32x32"/>
+<link rel="icon" href="icon/cropped-Icon-1-192x192.png" sizes="192x192"/>
+<link rel="apple-touch-icon" href="icon/cropped-Icon-1-180x180.png"/>
+<meta name="msapplication-TileImage" content="icon/cropped-Icon-1-270x270.png"/>
 <title>Smart Playground Wand — Game Icon Guide</title>
 <style>
   :root {


### PR DESCRIPTION
Add favicon, apple-touch-icon and msapplication-TileImage tags to multiple HTML pages (Live_Page/Code_Upload/index.html, Live_Page/If_Splats/index.html, Live_Page/Wand Pages/student-guide.html, Live_Page/WebApp/index.html, Live_Page/wand_icons.html) to provide consistent app icons across platforms. Replace embedded SVG data URIs in Live_Page/WebApp/manifest.json with PNG asset paths and correct the sizes/types (use 192x192 PNG and 270x270 PNG) for proper PWA icon support.